### PR TITLE
Make catalog layout responsive

### DIFF
--- a/css/catalog.css
+++ b/css/catalog.css
@@ -287,6 +287,10 @@ html, body {
   margin-bottom: 40px;
 }
 
+.filter-toggle {
+  display: none;
+}
+
 .catalog-content {
   flex: 1;
   display: flex;
@@ -353,5 +357,49 @@ html, body {
 }
 .quantity-controls .quantity-input[type="number"] {
   -moz-appearance: textfield;
+}
+
+/* Mobile styles */
+@media (max-width: 768px) {
+  .catalog-wrapper {
+    flex-direction: column;
+    padding: 0 16px;
+  }
+  .catalog-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .filters {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 80%;
+    max-width: 300px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    border-radius: 0 16px 16px 0;
+    box-shadow: 2px 0 10px rgba(0,0,0,0.5);
+    z-index: 10000;
+    overflow-y: auto;
+  }
+  .filters.open {
+    transform: translateX(0);
+  }
+  .filter-toggle {
+    display: flex;
+    position: fixed;
+    top: 80px;
+    left: 10px;
+    z-index: 10050;
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+    background: #F96000;
+    border: none;
+    border-radius: 8px;
+    color: #fff;
+    cursor: pointer;
+  }
 }
 

--- a/js/filter-toggle.js
+++ b/js/filter-toggle.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleBtn = document.getElementById('filterToggle');
+  const filters = document.querySelector('.filters');
+  if (!toggleBtn || !filters) return;
+
+  toggleBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    filters.classList.toggle('open');
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!filters.contains(e.target) && e.target !== toggleBtn) {
+      filters.classList.remove('open');
+    }
+  });
+});

--- a/main/catalog.html
+++ b/main/catalog.html
@@ -19,6 +19,7 @@
 </head>
 <body>
 
+  <button id="filterToggle" class="filter-toggle" aria-label="Фильтры">☰</button>
   <div class="catalog-wrapper">
     <aside class="filters">
       <input type="text" id="searchInput" placeholder="Поиск по названию" />
@@ -68,6 +69,7 @@
         document.getElementById('footer-placeholder').innerHTML = data;
       });
   </script>
-  
+  <script src="/scanmaster/js/filter-toggle.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust catalog layout for mobile screens
- add filter toggle button and slide-in panel
- support 2-column product grid on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403e35f71083259afd03b4034c6858